### PR TITLE
let var systemmonitorAvailableSources refer to an empty array.

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -190,6 +190,10 @@ Item {
 
         temperatureModel.clear()
 
+        if (!systemmonitorAvailableSources) {
+            systemmonitorAvailableSources = []
+        }
+
         if (!systemmonitorSourcesToAdd) {
             systemmonitorSourcesToAdd = []
         }


### PR DESCRIPTION
Solves a situation where sources go to off state on plasma restart. 